### PR TITLE
Allow AAP to be non integer

### DIFF
--- a/MultiThreadIO.py
+++ b/MultiThreadIO.py
@@ -56,7 +56,7 @@ def split_by(array, step):
 
 
 
-def process_input_line(line, startsnp, stopsnp, dtype, nonInteger = False):
+def process_input_line(line, startsnp, stopsnp, dtype):
     parts = line.split(); 
     idx = parts[0]
     parts = parts[1:]
@@ -64,7 +64,7 @@ def process_input_line(line, startsnp, stopsnp, dtype, nonInteger = False):
     if startsnp is not None :
         parts = parts[startsnp : stopsnp + 1] #Offset 1 for id and 2 for id + include stopsnp
 
-    if nonInteger :
+    if dtype in [np.float16, np.float32, np.float64] :
         data = np.array([val for val in parts], dtype=dtype)
     else :
         data = np.array([int(val) for val in parts], dtype = dtype)
@@ -94,7 +94,7 @@ def process_input_line_plink(line, startsnp, stopsnp, dtype):
     return (idx, data)
 
 
-def readLines(fileName, startsnp, stopsnp, dtype, processor=process_input_line, nonInteger = False):
+def readLines(fileName, startsnp, stopsnp, dtype, processor=process_input_line):
     # print(f"Reading in file: {fileName}")
 
     try:
@@ -120,7 +120,7 @@ def readLines(fileName, startsnp, stopsnp, dtype, processor=process_input_line, 
 
         if iothreads <= 1:
             for line in f:
-                output.append(processor(line, startsnp = startsnp, stopsnp = stopsnp, dtype = dtype, nonInteger = nonInteger))
+                output.append(processor(line, startsnp = startsnp, stopsnp = stopsnp, dtype = dtype))
 
     return output
 

--- a/MultiThreadIO.py
+++ b/MultiThreadIO.py
@@ -56,7 +56,7 @@ def split_by(array, step):
 
 
 
-def process_input_line(line, startsnp, stopsnp, dtype):
+def process_input_line(line, startsnp, stopsnp, dtype, nonInteger = False):
     parts = line.split(); 
     idx = parts[0]
     parts = parts[1:]
@@ -64,7 +64,10 @@ def process_input_line(line, startsnp, stopsnp, dtype):
     if startsnp is not None :
         parts = parts[startsnp : stopsnp + 1] #Offset 1 for id and 2 for id + include stopsnp
 
-    data=np.array([int(val) for val in parts], dtype = dtype)
+    if nonInteger :
+        data = np.array([val for val in parts], dtype=dtype)
+    else :
+        data = np.array([int(val) for val in parts], dtype = dtype)
 
     return (idx, data)
 
@@ -91,7 +94,7 @@ def process_input_line_plink(line, startsnp, stopsnp, dtype):
     return (idx, data)
 
 
-def readLines(fileName, startsnp, stopsnp, dtype, processor=process_input_line):
+def readLines(fileName, startsnp, stopsnp, dtype, processor=process_input_line, nonInteger = False):
     # print(f"Reading in file: {fileName}")
 
     try:
@@ -117,7 +120,7 @@ def readLines(fileName, startsnp, stopsnp, dtype, processor=process_input_line):
 
         if iothreads <= 1:
             for line in f:
-                output.append(processor(line, startsnp = startsnp, stopsnp = stopsnp, dtype = dtype))
+                output.append(processor(line, startsnp = startsnp, stopsnp = stopsnp, dtype = dtype, nonInteger = nonInteger))
 
     return output
 

--- a/Pedigree.py
+++ b/Pedigree.py
@@ -942,7 +942,7 @@ class Pedigree(object):
         :param fileName: The file path
         :type fileName: str
         """        
-        data_list = MultiThreadIO.readLines(fileName, startsnp=None, stopsnp=None, dtype = np.float32, nonInteger = True)
+        data_list = MultiThreadIO.readLines(fileName, startsnp=None, stopsnp=None, dtype = np.float32)
 
         # flag of whether adding a default alternative allele probability
         default_aap = False

--- a/Pedigree.py
+++ b/Pedigree.py
@@ -942,7 +942,7 @@ class Pedigree(object):
         :param fileName: The file path
         :type fileName: str
         """        
-        data_list = MultiThreadIO.readLines(fileName, startsnp=None, stopsnp=None, dtype = np.int64)
+        data_list = MultiThreadIO.readLines(fileName, startsnp=None, stopsnp=None, dtype = np.float32, nonInteger = True)
 
         # flag of whether adding a default alternative allele probability
         default_aap = False


### PR DESCRIPTION
Small updates to input the alt_allele_prob_file as a float rather than an integer (which is then turned into a float). This now allows the inputting of decimals such as 0.5, 0.45 which previously caused a valueError. 