### PR TITLE
Inclusion of phenotype information

### DIFF
--- a/InputOutput.py
+++ b/InputOutput.py
@@ -219,7 +219,27 @@ def readInPedigreeFromInputs(pedigree, args, genotypes=True, haps=False, reads=F
     if genotypes is not None: 
         for geno in args.genotypes:
             pedigree.readInGenotypes(geno, startsnp, stopsnp)
-    
+
+    phenoPenetrance = getattr(args, "phenoPenetrance", None)
+    if phenoPenetrance is not None:
+        for phenoPen in args.phenoPenetrance:
+            pedigree.readInPhenotypePenetrance(phenoPen)
+
+    phenotype = getattr(args, "phenotype", None)
+    if phenotype is not None:
+        if phenoPenetrance is None:
+            print("ERROR: To use phenotype information, please provide a phenotype penetrance via '-pheno_penetrance_file'\nExiting...")
+            sys.exit(2)
+        if pedigree.nLoci > 1:
+            # For now, this will be removed once mapping of phenotype to genotype is done.
+            print(
+                "ERROR: Currently phenotype information can only be used with a single locus genotype input. Please either remove the pheno_file or use a single locus genotype input.\nExiting..."
+                )
+            sys.exit(2)
+
+        for pheno in args.phenotype:
+            pedigree.readInPhenotype(pheno)
+
     reference = getattr(args, "reference", None)    
     if reference is not None: 
         for ref in args.reference:

--- a/Pedigree.py
+++ b/Pedigree.py
@@ -96,6 +96,8 @@ class Individual(object):
         self.genotypedFounderStatus = None #?
 
         self.MetaFounder = MetaFounder
+
+        self.phenotype = None
     
     def __eq__(self, other):
         return self is other
@@ -121,6 +123,10 @@ class Individual(object):
         if self.reads is not None:
             new_ind.reads = (self.reads[0][start:stop].copy(), self.reads[1][start:stop].copy())
         return new_ind
+    
+        if self.phenotype is not None:
+            new_ind.phenotype = self.phenotype.copy()
+    
 
     def getPercentMissing(self):
         return np.mean(self.genotypes == 9)
@@ -248,6 +254,9 @@ class Pedigree(object):
 
         self.MainMetaFounder = None
         self.AAP = {}
+
+        self.phenoPenetrance = None
+        self.nPheno = 0
 
         # remove?
         self.maf=None #Maf is the frequency of 2s.
@@ -879,6 +888,42 @@ class Pedigree(object):
 
             if np.mean(genotypes == 9) < .1 :
                 ind.initHD = True
+
+    def readInPhenotype(self, fileName):
+        """function for reading in phenotype input
+        
+        :param fileName: The file path
+        :type fileName: str
+        """
+        data_list = MultiThreadIO.readLines(fileName, startsnp=None, stopsnp=None, dtype = np.float32)
+
+        for value in data_list:
+            idx, pheno = value
+
+            nPheno = len(pheno)
+            if self.nPheno == 0:
+                self.nPheno = nPheno
+            if self.nPheno != nPheno:
+                print(f"ERROR: inconsistent number of phenotypes when reading in phenotype file. Expected {self.nPheno} got {nPheno}.\nExiting...")
+                sys.exit(2)
+
+            if idx not in self.individuals:
+                self.individuals[idx] = self.constructor(idx, self.maxIdn)
+                self.maxIdn += 1
+            ind = self.individuals[idx]
+            # Allows multiple phenotype inputs.
+            ind.phenotype = np.full(self.nPheno, pheno, dtype = np.int8)
+
+    def readInPhenotypePenetrance(self, fileName):
+        """
+        function for reading in the phenotype penetrance input
+        :param fileName: The file path
+        :type filename: str
+        """
+
+        self.phenoPenetrance = np.loadtxt(fileName, dtype = np.float32)
+        self.phenoPenetrance = self.phenoPenetrance / np.sum(self.phenoPenetrance, 1)[:,None] # Normalising of the phenotype penetrance input so all rows sum to 1.
+
 
     def readInReferencePanel(self, fileName, startsnp=None, stopsnp = None):
 

--- a/Pedigree.py
+++ b/Pedigree.py
@@ -127,7 +127,6 @@ class Individual(object):
         if self.phenotype is not None:
             new_ind.phenotype = self.phenotype.copy()
     
-
     def getPercentMissing(self):
         return np.mean(self.genotypes == 9)
 
@@ -922,6 +921,7 @@ class Pedigree(object):
     def readInPhenotypePenetrance(self, fileName):
         """
         function for reading in the phenotype penetrance input
+        
         :param fileName: The file path
         :type filename: str
         """

--- a/Pedigree.py
+++ b/Pedigree.py
@@ -900,6 +900,7 @@ class Pedigree(object):
         for value in data_list:
             idx, pheno = value
 
+            # Allows the input of multiple different phenotype traits.
             nPheno = len(pheno)
             if self.nPheno == 0:
                 self.nPheno = nPheno
@@ -911,8 +912,12 @@ class Pedigree(object):
                 self.individuals[idx] = self.constructor(idx, self.maxIdn)
                 self.maxIdn += 1
             ind = self.individuals[idx]
-            # Allows multiple phenotype inputs.
-            ind.phenotype = np.full(self.nPheno, pheno, dtype = np.int8)
+            
+            # List to store repeated phenotype records for the same trait.
+            if ind.phenotype == None:
+                ind.phenotype = []
+            ind.phenotype.append(np.full(self.nPheno, pheno, dtype = np.int8))
+
 
     def readInPhenotypePenetrance(self, fileName):
         """

--- a/ProbMath.py
+++ b/ProbMath.py
@@ -220,6 +220,11 @@ def generateErrorMat(error) :
     errorMat = errorMat/np.sum(errorMat, 1)[:,None]
     return errorMat
 
+def updateGenoProbsFromPhenotype(geno_probs, pheno, phenoPenetrance):
+    vals = geno_probs.copy() # Maybe does not need to be a copy?
+    vals = vals*phenoPenetrance[:,pheno].reshape(-1,1)
+    vals = vals/np.sum(vals, 0)[:None]
+    return vals
 
 def generateSegregationXXChrom(partial=False, e= 1e-06) :
     paternalTransmission = np.array([ [1, 1, 0, 0],[0, 0, 1, 1]])

--- a/ProbMath.py
+++ b/ProbMath.py
@@ -220,7 +220,7 @@ def generateErrorMat(error) :
     errorMat = errorMat/np.sum(errorMat, 1)[:,None]
     return errorMat
 
-def updateGenoProbsFromPhenotype(geno_probs, pheno, phenoPenetrance):
+def updateGenoProbsFromPhenotype(geno_probs, phenotypes, phenoPenetrance):
     vals = geno_probs.copy() # Maybe does not need to be a copy?
     # Where there are repeated phenotype records, continue to multiply the penetrance as assumed independent.
     repPhenotypes = len(phenotypes)
@@ -230,8 +230,9 @@ def updateGenoProbsFromPhenotype(geno_probs, pheno, phenoPenetrance):
         vals = vals*phenoPenetrance[:,pheno].reshape(-1,1)
         reps += 1
     
-    vals = vals/np.sum(vals, 0)[:None]
+    vals = vals/np.sum(vals, 0)
     return vals
+
 
 def generateSegregationXXChrom(partial=False, e= 1e-06) :
     paternalTransmission = np.array([ [1, 1, 0, 0],[0, 0, 1, 1]])

--- a/ProbMath.py
+++ b/ProbMath.py
@@ -222,7 +222,14 @@ def generateErrorMat(error) :
 
 def updateGenoProbsFromPhenotype(geno_probs, pheno, phenoPenetrance):
     vals = geno_probs.copy() # Maybe does not need to be a copy?
-    vals = vals*phenoPenetrance[:,pheno].reshape(-1,1)
+    # Where there are repeated phenotype records, continue to multiply the penetrance as assumed independent.
+    repPhenotypes = len(phenotypes)
+    reps = 0
+    while reps < repPhenotypes:
+        pheno = phenotypes[reps]
+        vals = vals*phenoPenetrance[:,pheno].reshape(-1,1)
+        reps += 1
+    
     vals = vals/np.sum(vals, 0)[:None]
     return vals
 

--- a/ProbMath.py
+++ b/ProbMath.py
@@ -221,7 +221,7 @@ def generateErrorMat(error) :
     return errorMat
 
 def updateGenoProbsFromPhenotype(geno_probs, phenotypes, phenoPenetrance):
-    vals = geno_probs.copy() # Maybe does not need to be a copy?
+    vals = geno_probs
     # Where there are repeated phenotype records, continue to multiply the penetrance as assumed independent.
     repPhenotypes = len(phenotypes)
     reps = 0


### PR DESCRIPTION
Updates for the input of phenotype information. This includes:
- Two new functions to read in the pheno_file and pheno_penetrance_file
- Error handling for cases where the user inputs pheno_file without pheno_penetrance_file or inputs a pheno_file with a geno_file containing multiple loci. This will be resolved in future, but for now, the pheno_input will only work with a single locus geno_file.
- New function updateGenoProbsFromPhenotypes. This multiples the genoProbs with the phenoPentrance of the inputted phenotype to update the penetrance term.

I have tested these changes locally. 