### PR TITLE
Feat/issue-36-add-doc-link-printout

### DIFF
--- a/InputOutput.py
+++ b/InputOutput.py
@@ -689,7 +689,7 @@ def getFamString(ind):
 #                     f.write('\n')
 
 
-def print_boilerplate(name, version=None, commit=None, date=None):
+def print_boilerplate(name, version=None, commit=None, date=None, docs=None):
     """Print software name, version and contact"""
     width = 42  # width of 'website' line
     print("-" * width)
@@ -701,6 +701,8 @@ def print_boilerplate(name, version=None, commit=None, date=None):
         print(f"Commit:  {commit}")
     if date is not None:
         print(f"Date:    {date}")
+    if docs is not None:
+        print(f"Docs:    {docs}")
 
     print("Email:   alphagenes.dev@gmail.com")
     print("Website: https://github.com/AlphaGenes")


### PR DESCRIPTION
## Related Issue
Closes https://github.com/AlphaGenes/tinyhouse/issues/36

Relates to https://github.com/AlphaGenes/AlphaPeel/issues/244

## What changed
- Add a line of documentation link printout to boilerplate

## Why this change
- As above

## Used by
- Main repository PR: <link> (if applicable)

## Notes
- Minor changes only